### PR TITLE
Correct DynamicCowTS version number

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -8599,7 +8599,7 @@
       "iconURL": "https://raw.githubusercontent.com/swaggyP36000/TrollStore-IPAs/main/icons/com.matteozappia.DynamicCowTS.png",
       "versions": [
         {
-          "version": "1.0",
+          "version": "2.0",
           "date": "2023-12-25",
           "size": 688532,
           "downloadURL": "https://github.com/swaggyP36000/TrollStore-IPAs/releases/download/12-22-2023/DynamicCowTS.ipa",


### PR DESCRIPTION
DynamicCowTS is listed in Trollstore-IPAs with the wrong version number, according to my testing. 

Please note that I haven't tested this PR and don't really know what I'm doing. Also, Github's online editor adds a newline to the end of files. If that is a problem, feel free to discard my pull request and fix the issue manually